### PR TITLE
Now asks "For<T>" a builder, instead of having to call Create()

### DIFF
--- a/src/NanoBuilder/NanoBuilder.Tests/ObjectBuilderTests.cs
+++ b/src/NanoBuilder/NanoBuilder.Tests/ObjectBuilderTests.cs
@@ -11,7 +11,7 @@ namespace NanoBuilder.Tests
       [Fact]
       public void Build_BuildingAnObject_ReturnsBuilderForThatType()
       {
-         var builder = ObjectBuilder<string>.Create();
+         var builder = ObjectBuilder.For<string>();
 
          builder.Should().BeOfType<ObjectBuilder<string>>();
       }
@@ -19,7 +19,7 @@ namespace NanoBuilder.Tests
       [Fact]
       public void Build_BuildingAnInt_ReturnsDefaultInt()
       {
-         int value = ObjectBuilder<int>.Create().Build();
+         int value = ObjectBuilder.For<int>().Build();
 
          value.Should().Be( default( int ) );
       }
@@ -27,7 +27,7 @@ namespace NanoBuilder.Tests
       [Fact]
       public void Build_BuildingAString_ReturnsDefaultString()
       {
-         string value = ObjectBuilder<string>.Create().Build();
+         string value = ObjectBuilder.For<string>().Build();
 
          value.Should().Be( default( string ) );
       }
@@ -37,7 +37,7 @@ namespace NanoBuilder.Tests
       {
          const string guidString = "86273ea7-b89d-45c2-a4f9-34f005e555da";
 
-         var guid = ObjectBuilder<Guid>.Create()
+         var guid = ObjectBuilder.For<Guid>()
             .With( () => guidString )
             .Build();
 
@@ -47,7 +47,7 @@ namespace NanoBuilder.Tests
       [Fact]
       public void Build_LeavesOneParameterUnmapped_UnmappedParameterIsDefaultValue()
       {
-         var eventArgs = ObjectBuilder<ProgressChangedEventArgs>.Create()
+         var eventArgs = ObjectBuilder.For<ProgressChangedEventArgs>()
             .With( () => 80 )
             .Build();
 
@@ -59,7 +59,7 @@ namespace NanoBuilder.Tests
       {
          var innerException = new OverflowException();
 
-         var exception = ObjectBuilder<Exception>.Create()
+         var exception = ObjectBuilder.For<Exception>()
             .With<Exception>( () => innerException )
             .Build();
 
@@ -71,7 +71,7 @@ namespace NanoBuilder.Tests
       {
          const int ambiguousInteger = 5;
 
-         Action build = () => ObjectBuilder<Version>.Create()
+         Action build = () => ObjectBuilder.For<Version>()
             .With( () => ambiguousInteger )
             .Build();
 
@@ -83,7 +83,7 @@ namespace NanoBuilder.Tests
       {
          const int ambiguousInteger = 5;
 
-         Action build = () => ObjectBuilder<Version>.Create()
+         Action build = () => ObjectBuilder.For<Version>()
             .With( () => ambiguousInteger )
             .Build();
 
@@ -98,7 +98,7 @@ namespace NanoBuilder.Tests
       {
          const int value = 5;
 
-         var vertex = ObjectBuilder<Vertex>.Create()
+         var vertex = ObjectBuilder.For<Vertex>()
             .With( () => value )
             .Build();
 

--- a/src/NanoBuilder/NanoBuilder/ObjectBuilder.cs
+++ b/src/NanoBuilder/NanoBuilder/ObjectBuilder.cs
@@ -1,24 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
 namespace NanoBuilder
 {
+   public static class ObjectBuilder
+   {
+      public static ObjectBuilder<T> For<T>() => new ObjectBuilder<T>();
+   }
+
    public class ObjectBuilder<T>
    {
       private readonly Dictionary<Type, TypeMapEntry> _typeMap = new Dictionary<Type, TypeMapEntry>();
 
-      private ObjectBuilder()
+      internal ObjectBuilder()
       {
       }
 
-      public static ObjectBuilder<T> Create() => new ObjectBuilder<T>();
-
-      public ObjectBuilder<T> With<TParameterType>( Expression<Func<TParameterType>> expr )
+      public ObjectBuilder<T> With<TParameterType>( Func<TParameterType> parameterProvider )
       {
-         var instance = expr.Compile()();
+         var instance = parameterProvider();
 
          _typeMap[typeof( TParameterType )] = new TypeMapEntry( instance );
 


### PR DESCRIPTION
This re-works the API, changing it from an ObjectBuilder-centric model (specifying the type parameter on that guy), so calling a For<T> method on ObjectBuilder, who then returns a different object to drill in. The use feels a little nicer, since the type parameter is more closely-related to what you're asking for.

This means ObjectBuilder is now a static class that acts as a factory to the new PropertyBuilder<T>, who now does all the heavy lifting.