### PR TITLE
Public API now hands around IParameterComposer abstractions, instead of concretes

### DIFF
--- a/src/NanoBuilder/NanoBuilder.Tests/ObjectBuilderTests.cs
+++ b/src/NanoBuilder/NanoBuilder.Tests/ObjectBuilderTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Reflection;
 using Xunit;
 using FluentAssertions;
 using Moq;

--- a/src/NanoBuilder/NanoBuilder.Tests/ObjectBuilderTests.cs
+++ b/src/NanoBuilder/NanoBuilder.Tests/ObjectBuilderTests.cs
@@ -126,17 +126,6 @@ namespace NanoBuilder.Tests
       }
 
       [Fact]
-      public void ConversionOperator_HasTimeSpanWithOneParameter_ConvertsComposerToTimeSpanAutomatically()
-      {
-         const long ticks = 123L;
-
-         TimeSpan timeSpan = ObjectBuilder.For<TimeSpan>()
-            .With( ticks );
-
-         timeSpan.Ticks.Should().Be( ticks );
-      }
-
-      [Fact]
       public void Skip_SkipsFirstConstructorButMapsSecond_SecondParameterIsSetButNotFirst()
       {
          const int y = 123;

--- a/src/NanoBuilder/NanoBuilder/IParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/IParameterComposer.cs
@@ -1,0 +1,39 @@
+﻿namespace NanoBuilder
+{
+   /// <summary>
+   /// A class that can configure constructor parameters.
+   /// </summary>
+   /// <typeparam name="T">The type of object to build.</typeparam>
+   public interface IParameterComposer<T>
+   {
+      /// <summary>
+      /// Configures how interface types should be initialized by default. 
+      /// </summary>
+      /// <typeparam name="TMapperType">The type of mapper to transform objects.</typeparam>
+      /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
+      ParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper;
+
+      /// <summary>
+      /// Configures a parameter for the object's constructor.
+      /// </summary>
+      /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
+      /// <param name="instance">The object that is being mapped for the given type.</param>
+      /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
+      ParameterComposer<T> With<TParameterType>( TParameterType instance );
+
+      /// <summary>
+      /// Provides a default value for the given type, allowing you to "skip" mapping a
+      /// parameter. This is useful when a constructor accepts multiple parameters of the
+      /// same type, and you want to map some of them (but not all).
+      /// </summary>
+      /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
+      /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
+      ParameterComposer<T> Skip<TParameterType>();
+
+      /// <summary>
+      /// Creates the instance with the configured constructor parameters.
+      /// </summary>
+      /// <returns>The object instance.</returns>
+      T Build();
+   }
+}

--- a/src/NanoBuilder/NanoBuilder/IParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/IParameterComposer.cs
@@ -11,7 +11,7 @@
       /// </summary>
       /// <typeparam name="TMapperType">The type of mapper to transform objects.</typeparam>
       /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
-      ParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper;
+      IParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper;
 
       /// <summary>
       /// Configures a parameter for the object's constructor.
@@ -19,7 +19,7 @@
       /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
       /// <param name="instance">The object that is being mapped for the given type.</param>
       /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
-      ParameterComposer<T> With<TParameterType>( TParameterType instance );
+      IParameterComposer<T> With<TParameterType>( TParameterType instance );
 
       /// <summary>
       /// Provides a default value for the given type, allowing you to "skip" mapping a
@@ -28,7 +28,7 @@
       /// </summary>
       /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
       /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
-      ParameterComposer<T> Skip<TParameterType>();
+      IParameterComposer<T> Skip<TParameterType>();
 
       /// <summary>
       /// Creates the instance with the configured constructor parameters.

--- a/src/NanoBuilder/NanoBuilder/NanoBuilder.csproj
+++ b/src/NanoBuilder/NanoBuilder/NanoBuilder.csproj
@@ -61,6 +61,7 @@
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="FakeItEasyMapper.cs" />
     <Compile Include="IConstructorMatcher.cs" />
+    <Compile Include="IParameterComposer.cs" />
     <Compile Include="MapperException.cs" />
     <Compile Include="NSubstituteMapper.cs" />
     <Compile Include="ParameterComposer.cs" />

--- a/src/NanoBuilder/NanoBuilder/ObjectBuilder.cs
+++ b/src/NanoBuilder/NanoBuilder/ObjectBuilder.cs
@@ -12,7 +12,7 @@
       /// </summary>
       /// <typeparam name="T">The type of object to build.</typeparam>
       /// <returns>An ObjectBuilder instance that can build the given type.</returns>
-      public static ParameterComposer<T> For<T>()
+      public static IParameterComposer<T> For<T>()
       {
          var constructors = typeof( T ).GetConstructors();
 

--- a/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
@@ -3,10 +3,6 @@ using System.Reflection;
 
 namespace NanoBuilder
 {
-   /// <summary>
-   /// A class that can configure constructor parameters.
-   /// </summary>
-   /// <typeparam name="T">The type of object to build.</typeparam>
    internal class ParameterComposer<T> : IParameterComposer<T>
    {
       private readonly ConstructorInfo[] _constructors;
@@ -36,11 +32,6 @@ namespace NanoBuilder
          return instance;
       }
 
-      /// <summary>
-      /// Configures how interface types should be initialized by default. 
-      /// </summary>
-      /// <typeparam name="TMapperType">The type of mapper to transform objects.</typeparam>
-      /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
       public IParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper
       {
          if ( _interfaceMapper != null )
@@ -55,12 +46,6 @@ namespace NanoBuilder
          return this;
       }
 
-      /// <summary>
-      /// Configures a parameter for the object's constructor.
-      /// </summary>
-      /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
-      /// <param name="instance">The object that is being mapped for the given type.</param>
-      /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
       public IParameterComposer<T> With<TParameterType>( TParameterType instance )
       {
          var parameterMatches = from c in _constructors
@@ -79,13 +64,6 @@ namespace NanoBuilder
          return this;
       }
 
-      /// <summary>
-      /// Provides a default value for the given type, allowing you to "skip" mapping a
-      /// parameter. This is useful when a constructor accepts multiple parameters of the
-      /// same type, and you want to map some of them (but not all).
-      /// </summary>
-      /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
-      /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
       public IParameterComposer<T> Skip<TParameterType>()
       {
          TParameterType instance = Default<TParameterType>();
@@ -95,10 +73,6 @@ namespace NanoBuilder
          return this;
       }
 
-      /// <summary>
-      /// Creates the instance with the configured constructor parameters.
-      /// </summary>
-      /// <returns>The object instance.</returns>
       public T Build()
       {
          if ( SpecialType.CanAutomaticallyActivate<T>() || !SpecialType.HasConstructors<T>() )

--- a/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
@@ -7,7 +7,7 @@ namespace NanoBuilder
    /// A class that can configure constructor parameters.
    /// </summary>
    /// <typeparam name="T">The type of object to build.</typeparam>
-   public class ParameterComposer<T> : IParameterComposer<T>
+   internal class ParameterComposer<T> : IParameterComposer<T>
    {
       private readonly ConstructorInfo[] _constructors;
       private readonly ITypeInspector _typeInspector;
@@ -16,7 +16,7 @@ namespace NanoBuilder
       private readonly TypeMap _typeMap = new TypeMap();
       private ITypeMapper _interfaceMapper;
 
-      internal ParameterComposer( ConstructorInfo[] constructors, ITypeInspector typeInspector, IConstructorMatcher constructorMatcher )
+      public ParameterComposer( ConstructorInfo[] constructors, ITypeInspector typeInspector, IConstructorMatcher constructorMatcher )
       {
          _constructors = constructors;
          _typeInspector = typeInspector;
@@ -41,7 +41,7 @@ namespace NanoBuilder
       /// </summary>
       /// <typeparam name="TMapperType">The type of mapper to transform objects.</typeparam>
       /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
-      public ParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper
+      public IParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper
       {
          if ( _interfaceMapper != null )
          {
@@ -61,7 +61,7 @@ namespace NanoBuilder
       /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
       /// <param name="instance">The object that is being mapped for the given type.</param>
       /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
-      public ParameterComposer<T> With<TParameterType>( TParameterType instance )
+      public IParameterComposer<T> With<TParameterType>( TParameterType instance )
       {
          var parameterMatches = from c in _constructors
                                 from p in c.GetParameters()
@@ -86,7 +86,7 @@ namespace NanoBuilder
       /// </summary>
       /// <typeparam name="TParameterType">The type of object for the constructor.</typeparam>
       /// <returns>The same <see cref="ParameterComposer{T}"/>.</returns>
-      public ParameterComposer<T> Skip<TParameterType>()
+      public IParameterComposer<T> Skip<TParameterType>()
       {
          TParameterType instance = Default<TParameterType>();
 
@@ -135,16 +135,5 @@ namespace NanoBuilder
 
          return (T) constructor.Invoke( callingParameters );
       }
-
-      /// <summary>
-      /// Automatically builds the instance from the <see cref="ParameterComposer{T}"/>. Using this
-      /// means a call to Build() is unnecessary.
-      /// </summary>
-      /// <param name="composer">
-      /// The current <see cref="ParameterComposer{T}"/>. This is most useful when
-      /// chaining together method calls.
-      /// </param>
-      public static implicit operator T( ParameterComposer<T> composer )
-         => composer.Build();
    }
 }

--- a/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Net.Sockets;
 using System.Reflection;
 
 namespace NanoBuilder

--- a/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
@@ -7,7 +7,7 @@ namespace NanoBuilder
    /// A class that can configure constructor parameters.
    /// </summary>
    /// <typeparam name="T">The type of object to build.</typeparam>
-   public class ParameterComposer<T>
+   public class ParameterComposer<T> : IParameterComposer<T>
    {
       private readonly ConstructorInfo[] _constructors;
       private readonly ITypeInspector _typeInspector;


### PR DESCRIPTION
Gives some wiggle room for the future. But this means the implicit operator had to go, since they only work on concretes.