### PR TITLE
Now throwing a more helpful message if a Mock<T> can't be mapped to any parameters

### DIFF
--- a/src/NanoBuilder/NanoBuilder.Tests/ParameterComposerTests.cs
+++ b/src/NanoBuilder/NanoBuilder.Tests/ParameterComposerTests.cs
@@ -8,7 +8,7 @@ namespace NanoBuilder.Tests
    public class ParameterComposerTests
    {
       [Fact]
-      public void Create_PassesMoqMapper_UsesFactoryToCreateMapper()
+      public void MapInterfacesTo_PassesMoqMapper_UsesFactoryToCreateMapper()
       {
          // Arrange
 

--- a/src/NanoBuilder/NanoBuilder.Tests/ParameterComposerTests.cs
+++ b/src/NanoBuilder/NanoBuilder.Tests/ParameterComposerTests.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using FluentAssertions;
 using Moq;
+using NanoBuilder.Tests.Stubs;
 
 namespace NanoBuilder.Tests
 {
@@ -45,6 +46,27 @@ namespace NanoBuilder.Tests
          Action map = () => parameterComposer.MapInterfacesTo<ITypeMapper>();
 
          map.ShouldThrow<MapperException>();
+      }
+
+      [Fact]
+      public void With_PassesMockInsteadOfMockObject_ThrowsWithHelpfulMessage()
+      {
+         // Arrange
+
+         var typeInspectorMock = new Mock<ITypeInspector>();
+
+         // Act
+
+         var fileSystemMock = new Mock<IFileSystem>();
+
+         var parameterComposer = new ParameterComposer<Logger>( typeInspectorMock.Object, null, null );
+
+         Action with = () => parameterComposer.With( fileSystemMock );
+
+         // Assert
+
+         string message = Resources.ParameterMappingWithMockMessage.Replace( "{0}", "*" );
+         with.ShouldThrow<ParameterMappingException>().And.Message.Should().Match( message );
       }
    }
 }

--- a/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
@@ -57,7 +57,17 @@ namespace NanoBuilder
 
          if ( !parameterMatches.Any() )
          {
-            string message = string.Format( Resources.ParameterMappingMessage, typeof( T ), typeof( TParameterType ) );
+            string message;
+
+            if ( instance.GetType().Name == "Mock`1" )
+            {
+               message = string.Format( Resources.ParameterMappingWithMockMessage, typeof( T ) );
+            }
+            else
+            {
+               message = string.Format( Resources.ParameterMappingMessage, typeof( T ), typeof( TParameterType ) );
+            }
+
             throw new ParameterMappingException( message );
          }
 

--- a/src/NanoBuilder/NanoBuilder/Resources.cs
+++ b/src/NanoBuilder/NanoBuilder/Resources.cs
@@ -1,4 +1,6 @@
-﻿namespace NanoBuilder
+﻿using System;
+
+namespace NanoBuilder
 {
    internal static class Resources
    {
@@ -15,6 +17,8 @@
       public const string NSubstituteMapperMessage = "Unable to locate NSubstitute.Substitute type. Are you referencing NSubstitute?";
 
       public const string ParameterMappingMessage = "No public constructors on type {0} were found to accept a parameter of type {1}";
+
+      public const string ParameterMappingWithMockMessage = "No public constructors on type {0} accept a Mock instance. Did you mean to pass the Mock.Object?";
 
       public const string RhinoMocksMapperMessage = "Unable to locate the Rhino.Mocks.MockRepository type. Are you referencing RhinoMocks?";
    }


### PR DESCRIPTION
This is a UX thing--it's possible that you forgot to pass ".Object" and just passed the mock.