### PR TITLE
Renaming MapInterfacesTo -> MapInterfacesWith

### DIFF
--- a/src/NanoBuilder/NanoBuilder.AcceptanceTests/MapInterfacesScenarios.cs
+++ b/src/NanoBuilder/NanoBuilder.AcceptanceTests/MapInterfacesScenarios.cs
@@ -16,7 +16,7 @@ namespace NanoBuilder.AcceptanceTests
          const int cacheSize = 256;
 
          var fileSystemCache = ObjectBuilder.For<FileSystemCache>()
-            .MapInterfacesTo<MoqMapper>()
+            .MapInterfacesWith<MoqMapper>()
             .With( cacheSize )
             .Build();
 
@@ -28,7 +28,7 @@ namespace NanoBuilder.AcceptanceTests
       public void CanMapInterfacesToMoqMocks()
       {
          var logger = ObjectBuilder.For<Logger>()
-            .MapInterfacesTo<MoqMapper>()
+            .MapInterfacesWith<MoqMapper>()
             .Build();
 
          Mock.Get( logger.FileSystem ).Should().BeOfType<Mock<IFileSystem>>();
@@ -38,7 +38,7 @@ namespace NanoBuilder.AcceptanceTests
       public void CanMapInterfacesToRhinoMocks()
       {
          var logger = ObjectBuilder.For<Logger>()
-            .MapInterfacesTo<RhinoMocksMapper>()
+            .MapInterfacesWith<RhinoMocksMapper>()
             .Build();
 
          logger.FileSystem.GetType().GetInterfaces().Should().Contain( typeof( IMockedObject ) );
@@ -48,7 +48,7 @@ namespace NanoBuilder.AcceptanceTests
       public void CanMapInterfacesToNSubstituteMocks()
       {
          var logger = ObjectBuilder.For<Logger>()
-            .MapInterfacesTo<NSubstituteMapper>()
+            .MapInterfacesWith<NSubstituteMapper>()
             .Build();
 
          logger.FileSystem.GetType().GetInterfaces().Should().Contain( typeof( ICallRouter ) );
@@ -58,7 +58,7 @@ namespace NanoBuilder.AcceptanceTests
       public void CanMapInterfacesToFakeItEasyMocks()
       {
          var logger = ObjectBuilder.For<Logger>()
-            .MapInterfacesTo<FakeItEasyMapper>()
+            .MapInterfacesWith<FakeItEasyMapper>()
             .Build();
 
          logger.FileSystem.GetType().GetInterfaces().Should().Contain( typeof( ITaggable ) );

--- a/src/NanoBuilder/NanoBuilder.AcceptanceTests/ParameterSkippingScenarios.cs
+++ b/src/NanoBuilder/NanoBuilder.AcceptanceTests/ParameterSkippingScenarios.cs
@@ -27,7 +27,7 @@ namespace NanoBuilder.AcceptanceTests
          var fileSystemMock = new Mock<IFileSystem>();
 
          var fileSystemAggregator = ObjectBuilder.For<FileSystemAggregator>()
-            .MapInterfacesTo<MoqMapper>()
+            .MapInterfacesWith<MoqMapper>()
             .Skip<IFileSystem>()
             .With( fileSystemMock.Object )
             .Build();

--- a/src/NanoBuilder/NanoBuilder.UnitTests/ParameterComposerTests.cs
+++ b/src/NanoBuilder/NanoBuilder.UnitTests/ParameterComposerTests.cs
@@ -9,7 +9,7 @@ namespace NanoBuilder.UnitTests
    public class ParameterComposerTests
    {
       [Fact]
-      public void MapInterfacesTo_PassesMoqMapper_UsesFactoryToCreateMapper()
+      public void MapInterfacesWith_PassesMoqMapper_UsesFactoryToCreateMapper()
       {
          // Arrange
 
@@ -21,7 +21,7 @@ namespace NanoBuilder.UnitTests
 
          var parameterComposer = new FullParameterComposer<int>( typeInspectorMock.Object, null, mapperFactoryMock.Object, typeActivatorMock.Object, null );
 
-         parameterComposer.MapInterfacesTo<MoqMapper>();
+         parameterComposer.MapInterfacesWith<MoqMapper>();
          
          // Assert
 

--- a/src/NanoBuilder/NanoBuilder/IMappedInterfaceConstraint.cs
+++ b/src/NanoBuilder/NanoBuilder/IMappedInterfaceConstraint.cs
@@ -11,6 +11,6 @@
       /// </summary>
       /// <typeparam name="TMapperType">The type of mapper to transform objects.</typeparam>
       /// <returns>The same <see cref="FullParameterComposer{T}"/>.</returns>
-      IParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper;
+      IParameterComposer<T> MapInterfacesWith<TMapperType>() where TMapperType : ITypeMapper;
    }
 }

--- a/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterComposer.cs
@@ -26,7 +26,7 @@ namespace NanoBuilder
          _typeMap = typeMap;
       }
 
-      public IParameterComposer<T> MapInterfacesTo<TMapperType>() where TMapperType : ITypeMapper
+      public IParameterComposer<T> MapInterfacesWith<TMapperType>() where TMapperType : ITypeMapper
       {
          _interfaceMapper = _mapperFactory.Create<TMapperType>();
 


### PR DESCRIPTION
Lends itself better to the fluency of the "X Mapper." The other option was to keep "MapInterfacesTo," but rename the mappers themselves, to read more like "MapInterfacesTo<Moq>." Reads pretty well, but then we're stuck with classes named "Moq" and "RhinoMocks" and other weird crap.